### PR TITLE
Retry transient source downloads during build

### DIFF
--- a/config/templates/craft.yml.twig
+++ b/config/templates/craft.yml.twig
@@ -82,6 +82,10 @@ download-options:
     prefer-pre-built: false
     no-alt: false
     shallow-clone: true
+    # Retry transient GitHub API / network failures instead of aborting the whole
+    # build. spc defaults retry to 0, so a single flaky tags/release API call (e.g.
+    # a slow api.github.com response) would otherwise kill the entire libs build.
+    retry: 3
     ignore-cache-sources: '{{ ci ? 'php-src' : '' }}'
 craft-options:
     doctor: true

--- a/config/templates/craft.yml.twig
+++ b/config/templates/craft.yml.twig
@@ -82,10 +82,7 @@ download-options:
     prefer-pre-built: false
     no-alt: false
     shallow-clone: true
-    # Retry transient GitHub API / network failures instead of aborting the whole
-    # build. spc defaults retry to 0, so a single flaky tags/release API call (e.g.
-    # a slow api.github.com response) would otherwise kill the entire libs build.
-    retry: 3
+    retry: 5
     ignore-cache-sources: '{{ ci ? 'php-src' : '' }}'
 craft-options:
     doctor: true


### PR DESCRIPTION
spc's download retry option defaults to 0, so a single flaky GitHub API / network response (e.g. a slow api.github.com/repos/.../tags call) aborts the entire libs build. Set retry: 3 in the craft download-options so transient failures are retried instead of being fatal.


Claude-Session: https://claude.ai/code/session_01K6KeFEQiy1wY9F2s9VQVrd